### PR TITLE
Added -a flag to output only matching IP addresses

### DIFF
--- a/scanreport.sh
+++ b/scanreport.sh
@@ -35,11 +35,11 @@ if [[ ! -z $ip ]]; then # search by IP
 	echo -e "$r"
 
 elif [[ ! -z $port ]]; then # search by port number
-	r=$(grep -w -e "$port\/open" "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' |  tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | grep -e "Host: " -e ^${port} | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
+	r=$(grep -w -E -e "($port)\/open" "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' |  tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | grep -E -e "Host: " -e "^(${port})" | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
 	echo -e "$r"
 
 elif [[ ! -z $service ]]; then # search by service name
-	r=$(grep -w -i $service "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' |  tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | grep -i -e "Host: " -e ${service} | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
+	r=$(grep -w -E -i -e "($service)" "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' |  tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | grep -i -E -e "Host: " -e "(${service})" | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
 	echo -e "$r"
 
 else

--- a/scanreport.sh
+++ b/scanreport.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 function usage {
-	echo "usage: $1 [-f nmap.grepable] [-i IP] [-p port] [-s service] [-P protocol]"
+	echo "Usage: $1 [-f nmap.grepable] [-i IP] [-p port] [-s service] [-P protocol] [-a]"
+	echo "  -a: outputs matching IP addresses only"
 }
 
 db=""
@@ -9,13 +10,15 @@ ip=""
 port=""
 all=0
 proto=""
-while getopts "f:i:p:P:s:" OPT; do
+addressonly=""
+while getopts "f:i:p:P:s:a" OPT; do
 	case $OPT in
 		f) db=$OPTARG;;
 		i) ip=$OPTARG;;
 		p) port=$OPTARG;;
 		s) service=$OPTARG;;
 		P) proto=$OPTARG;;
+		a) addressonly=true;;
 		*) usage $0; exit;;
 	esac
 done
@@ -32,17 +35,19 @@ fi
 
 if [[ ! -z $ip ]]; then # search by IP
 	r=$(grep -w $ip "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' |  tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
-	echo -e "$r"
 
 elif [[ ! -z $port ]]; then # search by port number
 	r=$(grep -w -E -e "($port)\/open" "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' |  tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | grep -E -e "Host: " -e "^(${port})" | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
-	echo -e "$r"
 
 elif [[ ! -z $service ]]; then # search by service name
 	r=$(grep -w -E -i -e "($service)" "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' |  tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | grep -i -E -e "Host: " -e "(${service})" | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
-	echo -e "$r"
 
 else
 	r=$(cat "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' | tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
+fi
+
+if [[ ! -z $addressonly ]]; then # output only IPs/hostnames
+	echo -e "$r" | grep "Host:" | awk {'print $2'}
+else
 	echo -e "$r"
 fi

--- a/scanreport.sh
+++ b/scanreport.sh
@@ -46,7 +46,7 @@ else
 	r=$(cat "$db" | grep -v ^# | sed 's/Ports: /\'$'\n/g' | tr '/' '\t' | tr ',' '\n' | sed 's/^ //g' | grep -v "Status: Up" | sed 's/Host:/\\033[0;32mHost:\\033[0;39m/g' | sed 's/Ignored State.*$//')
 fi
 
-if [[ ! -z $addressonly ]]; then # output only IPs/hostnames
+if [[ $addressonly ]]; then # output only IPs/hostnames
 	echo -e "$r" | grep "Host:" | awk {'print $2'}
 else
 	echo -e "$r"


### PR DESCRIPTION
The -a flag will output just the IP addresses of the matching results. Can be used alongside all other flags (although kind of useless with -i).
